### PR TITLE
fix: test numpy>=2 (fastcluster v1.3.0 is upgraded for this)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ fastcluster
 matplotlib
 mnemonic
 natsort
-numpy<2
+numpy>=2
 pandas
 paramiko
 parasail


### PR DESCRIPTION
The `numpy` version was previous pinned for fastcluster with commit 8d51939

Newer version of `fastcluster` (v.1.3.0) requires numpy>=2